### PR TITLE
Seed missing synthetic data files

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,52 @@
+# Data Inventory
+
+This directory contains the research inputs and illustrative datasets used across the repository.
+
+## Synthetic data notice
+
+Some files in this repository are intentionally synthetic and exist to demonstrate schema, model inputs,
+and documentation flow without redistributing proprietary market data. Synthetic files are either suffixed
+with `_synthetic` or described as illustrative templates below.
+
+## Top-level files
+
+### `bank_source_ledger.csv`
+Verified source ledger for public claims used in reporting modules.
+
+### `example_corporate_profiles.csv`
+Illustrative corporate profiles used for strategy and reporting examples.
+
+### `india_transition_needs.csv`
+Reference dataset describing subsector-level transition financing needs.
+
+### `deal_economics.csv`
+Illustrative commercial-layer deal archetypes with synthetic deal counts, ticket sizes, and fee pools.
+Intended real-world sources: bank league tables, project finance deal databases, and internal pipeline analytics.
+
+### `sector_capital_needs.csv`
+Illustrative sector-level capital needs table aligned to transition-finance use cases in India.
+Intended real-world sources: NITI Aayog, IEA India Energy Outlook, sector reports, and company capex plans.
+
+### `bank_capabilities_template.csv`
+Illustrative template showing how a bank capability profile can be structured for strategy analysis.
+Intended real-world sources: annual reports, sustainability reports, and product framework pages.
+
+## Subfolders
+
+### `green_bonds/`
+- `issuance_history_synthetic.csv`
+- `pricing_spreads_synthetic.csv`
+
+Intended real-world sources: SEBI, BSE, NSE, Climate Bonds Initiative, and market data terminals.
+
+### `esg_scores/`
+- `nifty50_esg_metrics_synthetic.csv`
+- `sector_benchmarks_synthetic.csv`
+
+Intended real-world sources: BRSR filings, MSCI ESG Research, Sustainalytics, Bloomberg ESG.
+
+### `climate_scenarios/`
+- `india_net_zero_2070.json`
+- `sector_emissions_synthetic.csv`
+
+Intended real-world sources: NITI Aayog, IEA, MoEFCC, IPCC, and sector disclosures.

--- a/data/bank_capabilities_template.csv
+++ b/data/bank_capabilities_template.csv
@@ -1,0 +1,6 @@
+bank_name,renewables_project_finance,green_bond_underwriting,sustainability_linked_loans,transition_finance_advisory,trade_finance,warehouse_lines,guarantees,blended_finance,india_coverage,illustrative_flag
+Template Bank A,high,high,medium,medium,medium,low,medium,low,national,Y
+Template Bank B,medium,low,high,medium,high,medium,medium,low,regional,Y
+Template Bank C,high,medium,high,high,medium,medium,low,medium,global,Y
+Template Bank D,medium,medium,medium,low,high,low,high,low,national,Y
+Template Bank E,low,high,medium,high,low,medium,low,high,global,Y

--- a/data/climate_scenarios/README.md
+++ b/data/climate_scenarios/README.md
@@ -6,7 +6,7 @@
 India-specific climate scenario parameters for the net-zero 2070 pathway.
 Based on NITI Aayog and IEA India Energy Outlook.
 
-### `sector_emissions_synthetic.parquet`
+### `sector_emissions_synthetic.csv`
 Baseline and transition emissions by sector.
 See sources below for real data.
 

--- a/data/climate_scenarios/sector_emissions_synthetic.csv
+++ b/data/climate_scenarios/sector_emissions_synthetic.csv
@@ -1,0 +1,7 @@
+sector,baseline_year,baseline_emissions_mtco2e,emissions_2030_mtco2e,emissions_2050_mtco2e,emissions_intensity_index,transition_lever
+Power,2024,1120,860,210,100,renewables_and_storage
+Steel,2024,290,240,92,100,hydrogen_dri_and_scrap
+Cement,2024,210,176,78,100,clinker_substitution_and_ccus
+Transport,2024,340,255,95,100,fleet_electrification
+Buildings,2024,125,96,44,100,efficiency_and_cooling
+Agriculture,2024,410,372,250,100,methane_and_input_efficiency

--- a/data/deal_economics.csv
+++ b/data/deal_economics.csv
@@ -1,0 +1,7 @@
+subsector,lifecycle_stage,annual_deal_count,typical_ticket_inr_cr,fee_bps,estimated_fee_pool_inr_cr,primary_instrument,illustrative_flag,notes
+Utility-scale renewables,develop,18,1450,85,221.9,project_finance,Y,Illustrative synthetic pipeline for contracted renewable assets
+Grid and transmission upgrades,expand,9,2800,52,131.0,structured_term_loan,Y,Illustrative synthetic grid-upgrade financing mix
+Battery storage and flexible capacity,scale,11,1180,95,123.3,project_finance,Y,Illustrative synthetic storage deployment pipeline
+Green buildings and cooling retrofits,retrofit,24,265,115,73.1,green_loan,Y,Illustrative synthetic retrofit lending opportunity
+EV charging and fleet electrification,scale,21,180,140,52.9,sustainability_linked_loan,Y,Illustrative synthetic charging and fleet opportunity
+Industrial decarbonisation,transition,13,2350,105,320.8,transition_finance_loan,Y,Illustrative synthetic hard-to-abate transition capex

--- a/data/esg_scores/README.md
+++ b/data/esg_scores/README.md
@@ -25,6 +25,15 @@ Columns:
 ### `sector_benchmarks_synthetic.csv`
 Sector-level ESG percentile benchmarks for the Nifty 50 universe.
 
+Columns:
+- `sector`
+- `environmental_score_p25`
+- `environmental_score_p50`
+- `environmental_score_p75`
+- `social_score_p50`
+- `governance_score_p50`
+- `composite_esg_score_p50`
+
 ## Real Data Sources
 
 | Source | Coverage | Access |

--- a/data/esg_scores/sector_benchmarks_synthetic.csv
+++ b/data/esg_scores/sector_benchmarks_synthetic.csv
@@ -1,0 +1,7 @@
+sector,environmental_score_p25,environmental_score_p50,environmental_score_p75,social_score_p50,governance_score_p50,composite_esg_score_p50
+Information Technology,71,78,84,73,81,78.1
+Pharmaceuticals,64,70,77,68,74,70.4
+Financials,52,60,68,62,75,62.9
+Industrials,38,47,56,54,63,49.7
+Materials,29,37,46,48,57,40.1
+Energy,24,33,41,45,54,35.4

--- a/data/green_bonds/README.md
+++ b/data/green_bonds/README.md
@@ -20,7 +20,7 @@ Columns:
 - `external_review` — `second_party_opinion`, `certification`, `none`
 - `listed_exchange` — `BSE`, `NSE`, `both`
 
-### `pricing_spreads_synthetic.parquet`
+### `pricing_spreads_synthetic.csv`
 Illustrative credit spread data vs. duration-matched vanilla bonds.
 For real data, use Bloomberg or NSE/BSE bond analytics.
 

--- a/data/green_bonds/pricing_spreads_synthetic.csv
+++ b/data/green_bonds/pricing_spreads_synthetic.csv
@@ -1,0 +1,7 @@
+isin,issuer_name,issue_date,green_spread_bps,vanilla_matched_spread_bps,greenium_bps
+INE0GB100001,India Sovereign Green Bond 2033,2023-01-25,712,718,-6
+INE0GB100002,REC Green Bond 2029,2024-03-18,645,654,-9
+INE0GB100003,IREDA Green Bond 2031,2024-07-09,628,636,-8
+INE0GB100004,Axis Bank Green Bond 2028,2025-02-14,188,194,-6
+INE0GB100005,Adani Green Energy 2030,2025-06-27,342,351,-9
+INE0GB100006,NTPC Green Bond 2032,2025-09-30,255,262,-7

--- a/data/sector_capital_needs.csv
+++ b/data/sector_capital_needs.csv
@@ -1,0 +1,7 @@
+subsector,annual_capital_need_usd_bn,project_size_band,risk_profile,time_profile,market_maturity,kpi_readiness,illustrative_flag,source_note
+Utility-scale renewables,32.0,50-250m,core_plus,long,mature,medium,Y,Synthetic summary aligned to India transition financing themes
+Grid and transmission upgrades,24.0,>250m,core,long,mature,low,Y,Synthetic summary aligned to India transition financing themes
+Battery storage and flexible capacity,11.5,50-250m,core_plus,long,scaling,medium,Y,Synthetic summary aligned to India transition financing themes
+Green buildings and cooling retrofits,8.2,10-50m,core_plus,medium,mature,high,Y,Synthetic summary aligned to India transition financing themes
+EV charging and fleet electrification,14.8,10-50m,core_plus,medium,scaling,high,Y,Synthetic summary aligned to India transition financing themes
+Industrial decarbonisation,27.5,>250m,opportunistic,long,early,high,Y,Synthetic summary aligned to India transition financing themes


### PR DESCRIPTION
## Summary
- add the missing synthetic CSV datasets referenced by the repo data docs
- add a top-level data inventory README with intended real-world source notes
- align subfolder data READMEs to the CSV synthetic files committed in this branch

## Notes
- this addresses the data seeding/documentation gap described in issue #5
- I did not run tests because this change is limited to data/docs and the repo's advertised build pipeline is not present on current main

Closes #5